### PR TITLE
Fix dropdown not opening after closing

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1317,6 +1317,10 @@ export default {
     onSearchKeyDown(e) {
       const preventAndSelect = (e) => {
         e.preventDefault()
+        if (!this.open) {
+          this.open = true
+          return
+        }
         return !this.isComposing && this.typeAheadSelect()
       }
 

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -63,6 +63,15 @@ describe('Toggling Dropdown', () => {
     expect(Select.vm.search).toEqual('')
   })
 
+  it('should open dropdown on selectOnKeyCodes keydown', async () => {
+    const Select = mountDefault()
+    const input = Select.findComponent({ ref: 'search' })
+
+    input.trigger('keydown.enter')
+
+    expect(Select.vm.open).toEqual(true)
+  })
+
   it('should open dropdown on alphabetic input', async () => {
     const Select = mountDefault()
     const input = Select.findComponent({ ref: 'search' })

--- a/tests/unit/Keydown.spec.js
+++ b/tests/unit/Keydown.spec.js
@@ -19,6 +19,7 @@ describe('Custom Keydown Handlers', () => {
 
     const spy = jest.spyOn(Select.vm, 'typeAheadSelect')
 
+    Select.vm.open = true
     Select.findComponent({ ref: 'search' }).trigger('keydown.space')
 
     expect(spy).toHaveBeenCalledTimes(1)
@@ -33,6 +34,7 @@ describe('Custom Keydown Handlers', () => {
 
     const spy = jest.spyOn(Select.vm, 'typeAheadSelect')
 
+    Select.vm.open = true
     Select.findComponent({ ref: 'search' }).trigger('keydown.space')
     expect(onKeyDown.mock.calls.length).toBe(1)
 


### PR DESCRIPTION
### Reproduction

1) Open the dropdown on https://vue-select.org/sandbox.html
2) Close the dropdown by hitting the `Escape` key
3) Hit the `Enter` key

**Expected:** The dropdown opens

**Actual:** The dropdown remains closed