### PR TITLE
Add keyboard focus border for dropdown options

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -108,10 +108,11 @@
               isOptionDeselectable(option) && index === typeAheadPointer,
             'vs__dropdown-option--selected': isOptionSelected(option),
             'vs__dropdown-option--highlight': index === typeAheadPointer,
+            'vs__dropdown-option--kb-focus': hasKeyboardFocusBorder(index),
             'vs__dropdown-option--disabled': !selectable(option),
           }"
           :aria-selected="optionAriaSelected(option)"
-          @mouseover="selectable(option) ? (typeAheadPointer = index) : null"
+          @mousemove="onMouseMove(option, index)"
           @click.prevent.stop="selectable(option) ? select(option) : null"
         >
           <slot name="option" v-bind="normalizeOptionForSlot(option)">
@@ -662,6 +663,15 @@ export default {
     },
 
     /**
+     * Display a visible border around dropdown options
+     * which have keyboard focus.
+     */
+    keyboardFocusBorder: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * A unique identifier used to generate IDs in HTML.
      * Must be unique for every instance of the component.
      */
@@ -676,6 +686,7 @@ export default {
       search: '',
       open: false,
       isComposing: false,
+      isKeyboardNavigation: false,
       pushedTags: [],
       // eslint-disable-next-line vue/no-reserved-keys
       _value: [], // Internal value managed by Vue Select if no `value` prop is passed
@@ -1136,6 +1147,19 @@ export default {
     },
 
     /**
+     * Check if the option at the given index should display a
+     * keyboard focus border.
+     * @param  {Number} index
+     * @return {Boolean}
+     */
+    hasKeyboardFocusBorder(index) {
+      if (this.keyboardFocusBorder && this.isKeyboardNavigation) {
+        return index === this.typeAheadPointer
+      }
+      return false
+    },
+
+    /**
      * Determine if two option objects are matching.
      *
      * @param a {Object}
@@ -1325,6 +1349,20 @@ export default {
     },
 
     /**
+     * Event-Handler for option mousemove
+     * @param {Object|String} option
+     * @param {Number} index
+     * @return {void}
+     */
+    onMouseMove(option, index) {
+      this.isKeyboardNavigation = false
+      if (!this.selectable(option)) {
+        return
+      }
+      this.typeAheadPointer = index
+    },
+
+    /**
      * Search <input> KeyBoardEvent handler.
      * @param {KeyboardEvent} e
      * @return {Function}
@@ -1349,6 +1387,7 @@ export default {
         //  up.prevent
         38: (e) => {
           e.preventDefault()
+          this.isKeyboardNavigation = true
           if (!this.open) {
             this.open = true
             return
@@ -1358,6 +1397,7 @@ export default {
         //  down.prevent
         40: (e) => {
           e.preventDefault()
+          this.isKeyboardNavigation = true
           if (!this.open) {
             this.open = true
             return

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -54,7 +54,7 @@
     --vs-dropdown-option-padding: 3px 20px;
 
     /* Active State */
-    --vs-dropdown-option--active-bg: #5897fb;
+    --vs-dropdown-option--active-bg: #136cfb;
     --vs-dropdown-option--active-color: #fff;
 
     /* Deselect State */

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -57,6 +57,9 @@
     --vs-dropdown-option--active-bg: #136cfb;
     --vs-dropdown-option--active-color: #fff;
 
+    /* Keyboard Focus State */
+    --vs-dropdown-option--kb-focus-box-shadow: inset 0px 0px 0px 2px #949494;
+
     /* Deselect State */
     --vs-dropdown-option--deselect-bg: #fb5858;
     --vs-dropdown-option--deselect-color: #fff;

--- a/src/css/modules/dropdown-option.css
+++ b/src/css/modules/dropdown-option.css
@@ -14,6 +14,10 @@
     color: var(--vs-dropdown-option--active-color);
 }
 
+.vs__dropdown-option--kb-focus {
+    box-shadow: var(--vs-dropdown-option--kb-focus-box-shadow);
+}
+
 .vs__dropdown-option--deselect {
     background: var(--vs-dropdown-option--deselect-bg);
     color: var(--vs-dropdown-option--deselect-color);


### PR DESCRIPTION
Add keyboard focus border on dropdown options to improve accessibility similar to the examples below:

- [Single-select example](https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html)
- [Multi-select example](https://www.telerik.com/kendo-angular-ui/components/dropdowns/multiselect/accessibility/)

### Active background color

The default dropdown active background color is darkened `#5897fb` → `#136cfb` to meet minimum WCAG AA contrast ratio requirements

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/24800714/212228290-965968e7-6142-4d4f-9651-fab55634cee9.png) | ![image](https://user-images.githubusercontent.com/24800714/212228301-27a15474-3ab8-4d1e-b660-0bd987039a9b.png)
![image](https://user-images.githubusercontent.com/24800714/212228676-af57646a-c651-4caf-aaf6-c29199e1ae71.png) | ![image](https://user-images.githubusercontent.com/24800714/212228683-b7cd8c7d-9eaa-4fae-8fb1-6485d1167c65.png)

### Visible focus border

When keyboard navigation is detected a visible border `#949494` is added around the focused dropdown option

| | Screenshot
--- | ---
**Contrast** | ![image](https://user-images.githubusercontent.com/24800714/212229060-ee299e71-3132-4826-95fa-abb08fcff5df.png)
**Example** | ![image](https://user-images.githubusercontent.com/24800714/212229071-b1b177f8-70ae-4089-96ee-de292b889e42.png)

The example above uses
```js
keyboardFocusBorder: true,
```
and
```css
--vs-dropdown-option--active-bg: #f5f5f5;
--vs-dropdown-option--active-color: var(--vs-dropdown-option-color);
```