### PR TITLE
Fix keyboard focus not returning to input after clear

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1039,6 +1039,7 @@ export default {
         })
       )
       this.$emit('option:deselected', option)
+      this.searchEl.focus()
     },
 
     /**
@@ -1047,6 +1048,7 @@ export default {
      */
     clearSelection() {
       this.updateValue(this.multiple ? [] : null)
+      this.searchEl.focus()
     },
 
     /**

--- a/tests/unit/Deselecting.spec.js
+++ b/tests/unit/Deselecting.spec.js
@@ -112,6 +112,20 @@ describe('Removing values', () => {
     expect(deselect).not.toHaveBeenCalledWith('one')
   })
 
+  it('should return focus to the search input after deselect', () => {
+    const Select = selectWithProps({
+      multiple: true,
+      options: ['one', 'two', 'three'],
+      value: ['one'],
+    })
+
+    const deselect = Select.findComponent({ ref: 'deselectButtons' })
+    deselect.trigger('click')
+
+    const input = Select.findComponent({ ref: 'search' })
+    expect(document.activeElement).toEqual(input.element)
+  })
+
   describe('Clear button', () => {
     it('should be displayed on single select when value is selected', () => {
       const Select = selectWithProps({
@@ -155,6 +169,19 @@ describe('Removing values', () => {
       expect(Select.find('button.vs__clear').attributes().disabled).toEqual(
         'disabled'
       )
+    })
+
+    it('should return focus to the search input after clear', () => {
+      const Select = selectWithProps({
+        options: ['foo', 'bar'],
+        value: 'foo',
+      })
+
+      const clear = Select.findComponent({ ref: 'clearButton' })
+      clear.trigger('click')
+
+      const input = Select.findComponent({ ref: 'search' })
+      expect(document.activeElement).toEqual(input.element)
     })
   })
 })


### PR DESCRIPTION
### Reproduction

1) Open the dropdown on https://vue-select.org/sandbox.html
2) Select an option
3) Tab to the clear button and hit the `Enter` key

**Expected:** Focus returns to the search input

**Actual:** Focus returns to `body`

> The above reproduces when `:multiple="true"` and an option is deselected

Not applicable when an option is cleared with a mouse click in which case the focus stays on the search input