### PR TITLE
Fix return focus after keyboard deselect

### DIFF
--- a/tests/unit/Deselecting.spec.js
+++ b/tests/unit/Deselecting.spec.js
@@ -112,7 +112,7 @@ describe('Removing values', () => {
     expect(deselect).not.toHaveBeenCalledWith('one')
   })
 
-  it('should return focus to the search input after deselect', () => {
+  it('should return focus to the search input after keyboard deselect', () => {
     const Select = selectWithProps({
       multiple: true,
       options: ['one', 'two', 'three'],
@@ -120,10 +120,40 @@ describe('Removing values', () => {
     })
 
     const deselect = Select.findComponent({ ref: 'deselectButtons' })
-    deselect.trigger('click')
+    deselect.trigger('click', { pointerType: '' })
 
     const input = Select.findComponent({ ref: 'search' })
     expect(document.activeElement).toEqual(input.element)
+  })
+
+  it('should return focus to the next deselect after keyboard deselect', () => {
+    const Select = selectWithProps({
+      multiple: true,
+      options: ['one', 'two', 'three'],
+      value: ['one', 'two'],
+    })
+
+    const [deselect, nextDeselect] = Select.findAllComponents({
+      ref: 'deselectButtons',
+    }).wrappers
+
+    deselect.trigger('click', { pointerType: '' })
+    expect(document.activeElement).toEqual(nextDeselect.element)
+  })
+
+  it('should return focus to the previous deselect after keyboard deselect', () => {
+    const Select = selectWithProps({
+      multiple: true,
+      options: ['one', 'two', 'three'],
+      value: ['one', 'two'],
+    })
+
+    const [prevDeselect, deselect] = Select.findAllComponents({
+      ref: 'deselectButtons',
+    }).wrappers
+
+    deselect.trigger('click', { pointerType: '' })
+    expect(document.activeElement).toEqual(prevDeselect.element)
   })
 
   describe('Clear button', () => {


### PR DESCRIPTION
### Reproduction

1) Open the dropdown on https://vue-select.org/sandbox.html
2) Enable `:multiple="true"`
3) Select some options
4) Tab to an option deselect button and hit `Enter`

**Expected:** Focus returns to one of the remaining deselect buttons or the search input if no selected options remain

**Actual:** Focus return to `body`