### PR TITLE
Use browser agnostic handling for keyboard deselect focus

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -39,7 +39,8 @@
               class="vs__deselect"
               :title="`Deselect ${getOptionLabel(option)}`"
               :aria-label="`Deselect ${getOptionLabel(option)}`"
-              @click="(event) => deselect(option, index, event)"
+              @mousedown.stop="deselect(option)"
+              @keydown.enter="keyboardDeselect(option, index)"
             >
               <component :is="childComponents.Deselect" />
             </button>
@@ -1029,11 +1030,9 @@ export default {
     /**
      * De-select a given option.
      * @param  {Object|String} option
-     * @param  {Number} index
-     * @param  {PointerEvent} event
      * @return {void}
      */
-    deselect(option, index, event) {
+    deselect(option) {
       this.$emit('option:deselecting', option)
       this.updateValue(
         this.selectedValue.filter((val) => {
@@ -1041,23 +1040,30 @@ export default {
         })
       )
       this.$emit('option:deselected', option)
-      // Handle keyboard deselect
-      if (event?.pointerType === '') {
-        /**
-         * The index of the next deselect is not yet at the same index as the
-         * removed deselect element because Vue updates asynchronously
-         *
-         * $nextTick cannot be used as the tests will fail even after using
-         * $nextTick in the tests as well
-         */
-        const nextDeselect = this.$refs.deselectButtons?.[index + 1]
-        const prevDeselect = this.$refs.deselectButtons?.[index - 1]
-        const deselectToFocus = nextDeselect ?? prevDeselect
-        if (deselectToFocus) {
-          deselectToFocus.focus()
-        } else {
-          this.searchEl.focus()
-        }
+    },
+
+    /**
+     * De-select a given option on keyboard input.
+     * @param  {Object|String} option
+     * @param  {Number} index
+     * @return {void}
+     */
+    keyboardDeselect(option, index) {
+      this.deselect(option)
+      /**
+       * The index of the next deselect is not yet at the same index as the
+       * removed deselect element because Vue updates asynchronously
+       *
+       * $nextTick cannot be used as the tests will fail even after using
+       * $nextTick in the tests as well
+       */
+      const nextDeselect = this.$refs.deselectButtons?.[index + 1]
+      const prevDeselect = this.$refs.deselectButtons?.[index - 1]
+      const deselectToFocus = nextDeselect ?? prevDeselect
+      if (deselectToFocus) {
+        deselectToFocus.focus()
+      } else {
+        this.searchEl.focus()
       }
     },
 

--- a/tests/unit/Deselecting.spec.js
+++ b/tests/unit/Deselecting.spec.js
@@ -6,7 +6,7 @@ describe('Removing values', () => {
     Select.vm.$data._value = 'one'
     await Select.vm.$nextTick()
 
-    Select.find('.vs__deselect').trigger('click')
+    Select.find('.vs__deselect').trigger('mousedown')
     expect(Select.emitted().input).toEqual([[[]]])
     expect(Select.vm.selectedValue).toEqual([])
   })
@@ -120,7 +120,7 @@ describe('Removing values', () => {
     })
 
     const deselect = Select.findComponent({ ref: 'deselectButtons' })
-    deselect.trigger('click', { pointerType: '' })
+    deselect.trigger('keydown.enter')
 
     const input = Select.findComponent({ ref: 'search' })
     expect(document.activeElement).toEqual(input.element)
@@ -137,7 +137,7 @@ describe('Removing values', () => {
       ref: 'deselectButtons',
     }).wrappers
 
-    deselect.trigger('click', { pointerType: '' })
+    deselect.trigger('keydown.enter')
     expect(document.activeElement).toEqual(nextDeselect.element)
   })
 
@@ -152,7 +152,7 @@ describe('Removing values', () => {
       ref: 'deselectButtons',
     }).wrappers
 
-    deselect.trigger('click', { pointerType: '' })
+    deselect.trigger('keydown.enter')
     expect(document.activeElement).toEqual(prevDeselect.element)
   })
 


### PR DESCRIPTION
Fix https://github.com/nextcloud-deps/vue-select/pull/9 not working on Firefox

The original implementation expected a [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) which was the case in Chrome but not Firefox which provided a [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent)

Due to this discrepancy focus was not being returned on Firefox