### PR TITLE
Limit number of dropdown options

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -194,6 +194,15 @@ export default {
     },
 
     /**
+     * Sets the maximum number of options to display in the dropdown list
+     * @type {Number}
+     */
+    limit: {
+      type: Number,
+      default: null,
+    },
+
+    /**
      * Disable the entire component.
      * @type {Boolean}
      */
@@ -881,10 +890,17 @@ export default {
      * @return {array}
      */
     filteredOptions() {
+      const limitOptions = (options) => {
+        if (this.limit !== null) {
+          return options.slice(0, this.limit)
+        }
+        return options
+      }
+
       const optionList = [].concat(this.optionList)
 
       if (!this.filterable && !this.taggable) {
-        return optionList
+        return limitOptions(optionList)
       }
 
       let options = this.search.length
@@ -896,7 +912,7 @@ export default {
           options.unshift(createdOption)
         }
       }
-      return options
+      return limitOptions(options)
     },
 
     /**

--- a/tests/unit/Filtering.spec.js
+++ b/tests/unit/Filtering.spec.js
@@ -91,4 +91,27 @@ describe('Filtering Options', () => {
     Select.vm.search = '1'
     expect(Select.vm.filteredOptions).toEqual([1, 10])
   })
+
+  it('should return a limited number of options if limit is set', () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        options: ['foo', 'bar', 'baz', 'qux', 'quux'],
+        limit: 3,
+      },
+    })
+
+    expect(Select.vm.filteredOptions).toEqual(['foo', 'bar', 'baz'])
+  })
+
+  it('should return a limited number of options if limit is set and options are filtered', () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        options: ['b', 'bc', 'a', 'ab', 'abc'],
+        limit: 2,
+      },
+    })
+
+    Select.vm.search = 'a'
+    expect(Select.vm.filteredOptions).toEqual(['a', 'ab'])
+  })
 })


### PR DESCRIPTION
Add a `limit` prop to set the maximum number of options to display in the dropdown list