### PR TITLE
Fix calculated dropdown list width

### DIFF
--- a/src/directives/appendToBody.js
+++ b/src/directives/appendToBody.js
@@ -1,6 +1,8 @@
 export default {
   inserted(el, bindings, { context }) {
     if (context.appendToBody) {
+      document.body.appendChild(el)
+
       const {
         height,
         top,
@@ -16,8 +18,6 @@ export default {
         left: scrollX + left + 'px',
         top: scrollY + top + height + 'px',
       })
-
-      document.body.appendChild(el)
     }
   },
 


### PR DESCRIPTION
The calculated dropdown list width, passed to `calculatePosition()` when `appendToBody` is true, should be equal to the toggle width. Width is calculated before the dropdown list is appended to `body` and is still a child of the Select component.

If the Select component is mounted within a container that overflows and shows a scrollbar when a child dropdown list is opened, the toggle width is calculated with the scrollbar taken into account and therefore will equal the original toggle width minus the scrollbar width.

> When appended to `body` the dropdown list does not overflow the container

Thus `calculatePosition()` is given a width less than the toggle width.

To fix this discrepancy we mount the dropdown list to `body` before the calculation instead of after.