### PR TITLE
Allow disabling focus reset

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -510,6 +510,16 @@ export default {
     },
 
     /**
+     * If false, the focused dropdown option will not be reset when filtered
+     * options change.
+     * @type {Boolean}
+     */
+    resetFocusOnOptionsChange: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * When false, updating the options will not reset the selected value. Accepts
      * a `boolean` or `function` that returns a `boolean`. If defined as a function,
      * it will receive the params listed below.

--- a/src/mixins/typeAheadPointer.js
+++ b/src/mixins/typeAheadPointer.js
@@ -7,6 +7,9 @@ export default {
 
   watch: {
     filteredOptions() {
+      if (!this.resetFocusOnOptionsChange) {
+        return
+      }
       for (let i = 0; i < this.filteredOptions.length; i++) {
         if (this.selectable(this.filteredOptions[i])) {
           this.typeAheadPointer = i


### PR DESCRIPTION
Add the `resetFocusOnOptionsChange` prop to disable focus reset